### PR TITLE
fix: error throwed when query.data === null

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -123,7 +123,7 @@ export function useResource<I, O>(
         throw pending;
     }
 
-    if (query.data) {
+    if (query.hasOwnProperty('data')) {
         return [
             query.data,
             {


### PR DESCRIPTION
Case like following will cause error.

'Unexpected suspense state without data, pending and error';

```ts
const getLocalNote: () => Promise<string | null> = () => AsyncStorage.getItem('localNote');
const [result] = useResource(getLocalNote, undefined);
```