### PR TITLE
fix: withBoundary hoc type improve

### DIFF
--- a/src/hocs.tsx
+++ b/src/hocs.tsx
@@ -7,10 +7,10 @@ export interface WithBoundaryOptions<P = {}> extends Partial<Omit<SuspenseBounda
     pendingFallback?: Factory<SuspenseBoundaryProps['pendingFallback'], P>;
 }
 
-export function withBoundary<P = {}>(options: WithBoundaryOptions<P> = {}) {
+export function withBoundary(options: WithBoundaryOptions) {
     const {pendingFallback: pendingFactory, ...boundaryProps} = options;
 
-    return (ComponentIn: ComponentType<P>): SFC<P> => {
+    return <P extends {}>(ComponentIn: ComponentType<P>): SFC<P> => {
         const ComponentOut: SFC<P> = props => {
             const pendingFallback = typeof pendingFactory === 'function' ? pendingFactory(props) : pendingFactory;
             return (


### PR DESCRIPTION
Problem: 
The current `withBoundary` hoc asks for passing wrapped component's props to `withBoundary`, like: 

```
interface SharedwWorkspaceProps {
...
}

const SharedWorkspace: FC<SharedwWorkspaceProps> = ({...}) => {
 ...
}

withBoundary<SharedwWorkspaceProps>()(SharedWorkspace);
```

It's odd, the props of wrapped component should know the props types itself. Also, if omit `SharedwWorkspaceProps`, there will be type error, like

![image](https://user-images.githubusercontent.com/2955214/85189441-cc1c1680-b2e1-11ea-98d9-5db722d22831.png)

The following pull request makes the generic type from the inner function instead of from `withBoundary`.

There are still two questions: 

1.  The generic type for an arrow function felt odd. It must has `<P extends unknown>` to hint it is a generic type (ref this [stackoverflow question](https://stackoverflow.com/questions/32308370/what-is-the-syntax-for-typescript-arrow-functions-with-generics) question ). Would using `function` better? like:

```
...
function inner<P>(...) {
 ...
}
return inner;
...
```

2. Should be the `withBoundary` params optional? Now if omit params it complains, it has to be
```
withBoundary({})(Component);
```